### PR TITLE
misc: Prepare for paginated API responses

### DIFF
--- a/.romm/api.py
+++ b/.romm/api.py
@@ -201,6 +201,8 @@ class API:
             self._status.valid_credentials = False
             return
         platforms = json.loads(response.read().decode("utf-8"))
+        if isinstance(platforms, dict):
+            platforms = platforms["items"]
         _platforms: list[Platform] = []
         for platform in platforms:
             if platform["rom_count"] > 0:
@@ -258,6 +260,8 @@ class API:
             self._status.valid_credentials = False
             return
         collections = json.loads(response.read().decode("utf-8"))
+        if isinstance(collections, dict):
+            collections = collections["items"]
         _collections: list[Collection] = []
         for collection in collections:
             if collection["rom_count"] > 0:
@@ -321,6 +325,8 @@ class API:
             self._status.valid_credentials = False
             return
         roms = json.loads(response.read().decode("utf-8"))
+        if isinstance(roms, dict):
+            roms = roms["items"]
         _roms = [
             Rom(
                 id=rom["id"],


### PR DESCRIPTION
**Description**

The API will start returning paginated responses in the future, with a `items` key wrapping the actual data. This commit prepares the API client for this change by unwrapping the `items` key if it is present.