### PR TITLE
Fix .env exclude/include fields

### DIFF
--- a/RomM/api.py
+++ b/RomM/api.py
@@ -33,9 +33,9 @@ class API:
         self.username = os.getenv("USERNAME", "")
         self.password = os.getenv("PASSWORD", "")
         self.headers = {}
-        self._exclude_platforms = set(os.getenv("EXCLUDE_PLATFORMS") or [])
-        self._include_collections = set(os.getenv("INCLUDE_COLLECTIONS") or [])
-        self._exclude_collections = set(os.getenv("EXCLUDE_COLLECTIONS") or [])
+        self._exclude_platforms = set(self._getenv_list("EXCLUDE_PLATFORMS"))
+        self._include_collections = set(self._getenv_list("INCLUDE_COLLECTIONS"))
+        self._exclude_collections = set(self._getenv_list("EXCLUDE_COLLECTIONS"))
         self._collection_type = os.getenv("COLLECTION_TYPE", "collection")
         self._status = Status()
         self._file_system = Filesystem()
@@ -44,6 +44,11 @@ class API:
             credentials = f"{self.username}:{self.password}"
             auth_token = base64.b64encode(credentials.encode("utf-8")).decode("utf-8")
             self.headers = {"Authorization": f"Basic {auth_token}"}
+
+    @staticmethod
+    def _getenv_list(key: str) -> list[str]:
+        value = os.getenv(key)
+        return [item.strip() for item in value.split(",")] if value is not None else []
 
     @staticmethod
     def _human_readable_size(size_bytes: int) -> Tuple[float, str]:

--- a/RomM/env.template
+++ b/RomM/env.template
@@ -9,8 +9,8 @@ COLLECTION_TYPE=collection
 # Do not display platforms with these slugs (comma separated)
 # EXCLUDE_PLATFORMS=""
 
-# Only display collections with these slugs (comma separated)
+# Only display collections with these names (comma separated)
 # INCLUDE_COLLECTIONS=""
 
-# Do not display collections with these slugs (comma separated)
+# Do not display collections with these names (comma separated)
 # EXCLUDE_COLLECTIONS=""

--- a/RomM/env.template
+++ b/RomM/env.template
@@ -6,11 +6,11 @@ DEFAULT_SD_CARD=1
 # Can be one of genre, franchise, collection, mode or company
 COLLECTION_TYPE=collection
 
-# Do not display platforms with these names
-# EXCLUDE_PLATFORMS=[]
+# Do not display platforms with these slugs (comma separated)
+# EXCLUDE_PLATFORMS=""
 
-# Only display collections with these names
-# INCLUDE_COLLECTIONS=[]
+# Only display collections with these slugs (comma separated)
+# INCLUDE_COLLECTIONS=""
 
-# Do not display collections with these names
-# EXCLUDE_COLLECTIONS=[]
+# Do not display collections with these slugs (comma separated)
+# EXCLUDE_COLLECTIONS=""


### PR DESCRIPTION
**Description**

`os.getenv` returns `string | None`, so this code was previously just creating a set of every character in the value. For example:

```env
EXCLUDE_PLATFORMS=psp
```

would create a set of `{'p', 's'}`, which doesn't work when later doing the slug `in` check.

This PR updates the handling of this config to split by commas, so the user can pass:

```env
EXCLUDE_PLATFORMS="dc,n64,nds,psp,ps,saturn"
```

and have it work.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR

#### Screenshots
