### PR TITLE
Fix incorrect scaling on exit

### DIFF
--- a/RomM/mux_launch.sh
+++ b/RomM/mux_launch.sh
@@ -32,3 +32,10 @@ cd "${ROOT_DIR}" || exit
 LOG_FILE="${LOG_DIR}/$(date +'%Y-%m-%d_%H-%M-%S').log"
 
 python3 romm.py >"${LOG_FILE}" 2>&1
+
+SCREEN_TYPE="internal"
+if [ "$(GET_VAR "global" "boot/device_mode")" -eq 1 ]; then
+	SCREEN_TYPE="external"
+fi
+
+FB_SWITCH "$(GET_VAR "device" "screen/$SCREEN_TYPE/width")" "$(GET_VAR "device" "screen/$SCREEN_TYPE/height")" 32

--- a/RomM/mux_launch.sh
+++ b/RomM/mux_launch.sh
@@ -34,8 +34,11 @@ LOG_FILE="${LOG_DIR}/$(date +'%Y-%m-%d_%H-%M-%S').log"
 python3 romm.py >"${LOG_FILE}" 2>&1
 
 SCREEN_TYPE="internal"
-if [ "$(GET_VAR "global" "boot/device_mode")" -eq 1 ]; then
+DEVICE_MODE="$(GET_VAR "global" "boot/device_mode")"
+if [[ ${DEVICE_MODE} -eq 1 ]]; then
 	SCREEN_TYPE="external"
 fi
 
-FB_SWITCH "$(GET_VAR "device" "screen/$SCREEN_TYPE/width")" "$(GET_VAR "device" "screen/$SCREEN_TYPE/height")" 32
+DEVICE_WIDTH="$(GET_VAR "device" "screen/${SCREEN_TYPE}/width")"
+DEVICE_HEIGHT="$(GET_VAR "device" "screen/${SCREEN_TYPE}/height")"
+FB_SWITCH "${DEVICE_WIDTH}" "${DEVICE_HEIGHT}" 32


### PR DESCRIPTION
Fixes #28 

**Description**

Since the app scales at 640x480, but the rg34xx has a 720x480 display, we need to FB_SWITCH after exit to restore the system scaling to normal.

**Checklist**

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR

#### Screenshots
