### PR TITLE
Implement self-updater on application start

### DIFF
--- a/RomM/api.py
+++ b/RomM/api.py
@@ -517,9 +517,10 @@ class API:
                     self._reset_download_status()
                     return
                 print(f"Downloading {rom.name} to {dest_path}")
-                with urlopen(request) as response, open(  # trunk-ignore(bandit/B310)
-                    dest_path, "wb"
-                ) as out_file:
+                with (
+                    urlopen(request) as response,  # trunk-ignore(bandit/B310)
+                    open(dest_path, "wb") as out_file,
+                ):
                     self.status.total_downloaded_bytes = 0
                     chunk_size = 1024
                     while True:
@@ -557,9 +558,10 @@ class API:
                                     self._sanitize_filename(file.filename),
                                 )
                                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
-                                with zip_ref.open(file) as source, open(
-                                    file_path, "wb"
-                                ) as target:
+                                with (
+                                    zip_ref.open(file) as source,
+                                    open(file_path, "wb") as target,
+                                ):
                                     while True:
                                         chunk = source.read(chunk_size)
                                         if not chunk:

--- a/RomM/env.template
+++ b/RomM/env.template
@@ -1,4 +1,4 @@
-HOST="https://demo.romm.app/"
+HOST="https://demo.romm.app"
 USERNAME="demo"
 PASSWORD="demo"
 DEFAULT_SD_CARD=1

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -2,9 +2,25 @@
 
 import os
 import sys
+import zipfile
 
-# Add the PIL and dotenv dependencies to the path
 base_path = os.path.dirname(os.path.abspath(__file__))
+
+# The archive contains a RomM folder with the contents inside;
+# We want to extract to the folder above the current one so it overwrites our application correctly
+update_path = os.path.join(base_path, "..")
+
+# Apply update if found
+update_archive = [f for f in os.listdir(base_path) if f.endswith(".muxapp")]
+
+if update_archive:
+    with zipfile.ZipFile(os.path.join(base_path, update_archive[0]), 'r') as zip_ref:
+        zip_ref.extractall(update_path)
+
+    os.remove(os.path.join(base_path, update_archive[0]))
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+
+# Add dependencies to path
 libs_path = os.path.join(base_path, "deps")
 sys.path.insert(0, libs_path)
 

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -23,7 +23,7 @@ def apply_update() -> bool:
         with zipfile.ZipFile(update_file, "r") as zip_ref:
             zip_ref.extractall(update_path)
         os.remove(update_file)
-        os.execv(sys.executable, [sys.executable] + sys.argv)
+        os.execv(sys.executable, [sys.executable] + sys.argv)  # nosec B606
         return True
     except (zipfile.BadZipFile, OSError) as e:
         print(f"Failed to apply update: {e}", file=sys.stderr)

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -1,5 +1,3 @@
-# trunk-ignore-all(ruff/E402)
-
 import os
 import sys
 import zipfile
@@ -10,7 +8,7 @@ libs_path = os.path.join(base_path, "deps")
 sys.path.insert(0, libs_path)
 
 
-def apply_update() -> bool:
+def apply_pending_update() -> bool:
     # The archive contains a RomM folder with the contents inside
     # We want to extract to the folder above the current one so it overwrites our application correctly
     update_path = os.path.abspath(os.path.join(base_path, ".."))
@@ -23,15 +21,16 @@ def apply_update() -> bool:
         with zipfile.ZipFile(update_file, "r") as zip_ref:
             zip_ref.extractall(update_path)
         os.remove(update_file)
-        os.execv(sys.executable, [sys.executable] + sys.argv)  # nosec B606
-        return True
+
+        sys.stdout.close()
+        sys.exit(0)
     except (zipfile.BadZipFile, OSError) as e:
         print(f"Failed to apply update: {e}", file=sys.stderr)
         return False
 
 
 # Check for update before initializing since it may overwrite our dependencies
-if not apply_update():
+if not apply_pending_update():
     import sdl2
     from dotenv import load_dotenv
     from romm import RomM

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -9,6 +9,7 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 libs_path = os.path.join(base_path, "deps")
 sys.path.insert(0, libs_path)
 
+
 def apply_update() -> bool:
     # The archive contains a RomM folder with the contents inside
     # We want to extract to the folder above the current one so it overwrites our application correctly
@@ -19,7 +20,7 @@ def apply_update() -> bool:
 
     update_file = os.path.join(base_path, update_files[0])
     try:
-        with zipfile.ZipFile(update_file, 'r') as zip_ref:
+        with zipfile.ZipFile(update_file, "r") as zip_ref:
             zip_ref.extractall(update_path)
         os.remove(update_file)
         os.execv(sys.executable, [sys.executable] + sys.argv)
@@ -28,13 +29,16 @@ def apply_update() -> bool:
         print(f"Failed to apply update: {e}", file=sys.stderr)
         return False
 
+
 # Check for update before initializing since it may overwrite our dependencies
 if not apply_update():
-    from dotenv import load_dotenv
     import sdl2
+    from dotenv import load_dotenv
     from romm import RomM
+
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
     sys.stdout = open(os.environ.get("LOG_FILE", "./logs/log.txt"), "w", buffering=1)
+
 
 def cleanup(romm: RomM, exit_code: int):
     romm.ui.cleanup()

--- a/RomM/platform_maps.py
+++ b/RomM/platform_maps.py
@@ -2,9 +2,14 @@
 # This is sometimes needed to match custom system folders with defaults, for example ES-DE uses roms/gc and some Batocera forks use roms/gamecube
 # https://gitlab.com/es-de/emulationstation-de/-/blob/master/resources/systems/unix/es_systems.xml
 
-# Map: romm server system folder, romm client system folder, icon name
+# EmulationStation custom folder map
 _ES_FOLDER_MAP = {
-    "gc": ("gamecube", "ngc"),  # GameCube
+    #"slug": ("es-system", "icon"),
+    "ngc": ("gamecube", "ngc"),  # Nintendo GameCube
+    "n3ds": ("3ds", "3ds"), # Nintendo 3DS
+    "genesis": ("genesis", "genesis-slash-megadrive"), # Sega Genesis / Megadrive
+    "megadrive": ("megadrive", "genesis-slash-megadrive"), # Sega Genesis / Megadrive
+    "mastersystem": ("mastersystem", "sega-master-system"), # Sega Mastersystem
 }
 
 # Manual mapping of RomM slugs for MuOS default platforms

--- a/RomM/platform_maps.py
+++ b/RomM/platform_maps.py
@@ -4,12 +4,12 @@
 
 # EmulationStation custom folder map
 _ES_FOLDER_MAP = {
-    #"slug": ("es-system", "icon"),
+    # "slug": ("es-system", "icon"),
     "ngc": ("gamecube", "ngc"),  # Nintendo GameCube
-    "n3ds": ("3ds", "3ds"), # Nintendo 3DS
-    "genesis": ("genesis", "genesis-slash-megadrive"), # Sega Genesis / Megadrive
-    "megadrive": ("megadrive", "genesis-slash-megadrive"), # Sega Genesis / Megadrive
-    "mastersystem": ("mastersystem", "sega-master-system"), # Sega Mastersystem
+    "n3ds": ("3ds", "3ds"),  # Nintendo 3DS
+    "genesis": ("genesis", "genesis-slash-megadrive"),  # Sega Genesis / Megadrive
+    "megadrive": ("megadrive", "genesis-slash-megadrive"),  # Sega Genesis / Megadrive
+    "mastersystem": ("mastersystem", "sega-master-system"),  # Sega Mastersystem
 }
 
 # Manual mapping of RomM slugs for MuOS default platforms

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -107,8 +107,17 @@ class RomM:
             )
             self.ui.render_to_screen()
 
-        # Get latest release from GitHub API -- it has error handling so don't need to print here
+        # Get latest release from GitHub API
         release_info = self.updater.get_latest_release_info()
+
+        if release_info is None:
+            self.ui.draw_log(
+                text_line_1=f"{self.current_spinner_status} Failed to get release info, check internet connection"
+            )
+            self.ui.render_to_screen()
+            self.status.updating.clear()
+            sdl2.SDL_Delay(1000)
+            return
 
         latest_tag = release_info.get("tag_name", "")
         if not latest_tag:

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -183,7 +183,7 @@ class RomM:
                 if self.updater.download_update(self.download_url):
                     self.ui.draw_log(text_line_1="Update downloaded successfully")
                     # We need to restart here so main.py can extract the update before we've loaded anything into memory
-                    os.execv(sys.executable, [sys.executable] + sys.argv)
+                    os.execv(sys.executable, [sys.executable] + sys.argv)  # nosec B606
                 else:
                     self.ui.draw_log(text_line_1="Update failed")
                 self.ui.render_to_screen()

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -172,6 +172,8 @@ class RomM:
                 self.ui.draw_clear()
                 if self.updater.download_update(self.download_url):
                     self.ui.draw_log(text_line_1="Update downloaded successfully")
+                    # We need to restart here so main.py can extract the update before we've loaded anything into memory
+                    os.execv(sys.executable, [sys.executable] + sys.argv)
                 else:
                     self.ui.draw_log(text_line_1="Update failed")
                 self.ui.render_to_screen()

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import threading
 import time
 from typing import Any, Tuple
@@ -738,7 +739,7 @@ class RomM:
             return
 
         if self.status.updating.is_set():
-            return 
+            return
 
         if self.status.me_ready.is_set():
             self.ui.draw_header(self.api.host, self.api.username)

--- a/RomM/status.py
+++ b/RomM/status.py
@@ -54,6 +54,7 @@ class Status:
         self.download_rom_ready = threading.Event()
         self.abort_download = threading.Event()
         self.me_ready = threading.Event()
+        self.updating = threading.Event()
 
         # Initialize events what won't launch at startup
         self.roms_ready.set()

--- a/RomM/update.py
+++ b/RomM/update.py
@@ -4,7 +4,6 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 import sdl2
-
 from glyps import glyphs
 from ui import UserInterface
 

--- a/RomM/update.py
+++ b/RomM/update.py
@@ -67,7 +67,6 @@ class Update:
             return None
 
     def download_update(self, url):
-        self.status.updating.set()
         self.update_filename = os.path.basename(url)
         filepath = self.update_filename
 

--- a/RomM/update.py
+++ b/RomM/update.py
@@ -1,0 +1,109 @@
+import os
+import re
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import sdl2
+
+from glyps import glyphs
+from ui import UserInterface
+
+
+class Update:
+
+    REPO = "rommapp/muos-app"
+
+    def __init__(self, romm):
+        self.ui = UserInterface()
+        self.status = romm.status
+        self.current_version = self.get_current_version()
+        self.download_percent = 0.0
+        self.update_filename = ""
+        self.total_size = 0
+
+    def get_current_version(self):
+        """Read the version from __version__.py in the current directory."""
+        version_file = "__version__.py"
+        if not os.path.exists(version_file):
+            print("__version__.py not found")
+            return "0.0.0"
+
+        with open(version_file, "r") as f:
+            content = f.read()
+            match = re.search(r"version\s*=\s*['\"]([^'\"]+)['\"]", content)
+            if match:
+                return match.group(1)
+            else:
+                print("Failed to read version from __version__.py")
+                return "0.0.0"
+
+    def compare_versions(self, v1, v2):
+        """Compare two version strings (e.g., '0.3.0' < '0.4.0')."""
+        v1_parts = [int(x) for x in v1.split(".")]
+        v2_parts = [int(x) for x in v2.split(".")]
+        for i in range(max(len(v1_parts), len(v2_parts))):
+            part1 = v1_parts[i] if i < len(v1_parts) else 0
+            part2 = v2_parts[i] if i < len(v2_parts) else 0
+            if part1 < part2:
+                print(f"Current version: {v1}, Latest version: {v2}")
+                return -1
+            elif part1 > part2:
+                print(f"Current version: {v1}, Latest version: {v2}")
+                return 1
+        print(f"Current version: {v1}, Latest version: {v2}")
+        return 0
+
+    def get_latest_release_info(self):
+        url = f"https://api.github.com/repos/{self.REPO}/releases/latest"
+        try:
+            request = Request(url, headers={"Accept": "application/vnd.github.v3+json"})
+            with urlopen(request, timeout=10) as response:  # trunk-ignore(bandit/B310)
+                data = response.read().decode("utf-8")
+                import json
+
+                return json.loads(data)
+        except (HTTPError, URLError) as e:
+            print(f"Failed to fetch latest release info: {e}")
+            return None
+
+    def download_update(self, url):
+        self.status.updating.set()
+        self.update_filename = os.path.basename(url)
+        filepath = self.update_filename
+
+        try:
+            request = Request(url)
+            with urlopen(request) as response:  # trunk-ignore(bandit/B310)
+                self.total_size = int(response.getheader("Content-Length", 0)) or 1
+                self.download_percent = 0.0
+                downloaded_bytes = 0
+                chunk_size = 1024
+
+                with open(filepath, "wb") as out_file:
+                    while True:
+                        chunk = response.read(chunk_size)
+                        if not chunk:
+                            break
+                        out_file.write(chunk)
+                        downloaded_bytes += len(chunk)
+                        self.download_percent = min(
+                            100.0, (downloaded_bytes / self.total_size) * 100
+                        )
+                        self.ui.draw_loader(self.download_percent)
+                        self.ui.draw_log(
+                            text_line_1="Downloading update...",
+                            text_line_2=f"{self.download_percent:.2f} / 100 % | ( {glyphs.download} {filepath})",
+                            background=True,
+                        )
+                        self.ui.render_to_screen()
+                        sdl2.SDL_Delay(16)
+
+                self.status.updating.clear()
+                return True
+
+        except (HTTPError, URLError) as e:
+            print(f"Update download failed: {e}")
+            self.status.updating.clear()
+            if os.path.exists(filepath):
+                os.remove(filepath)
+            return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
   "pip>=25.0.1",
   "pysdl2>=0.9.17",
   "python-dotenv>=1.1.0",
+  "semver>=3.0.4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "pip" },
     { name = "pysdl2" },
     { name = "python-dotenv" },
+    { name = "semver" },
 ]
 
 [package.metadata]
@@ -19,6 +20,7 @@ requires-dist = [
     { name = "pip", specifier = ">=25.0.1" },
     { name = "pysdl2", specifier = ">=0.9.17" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "semver", specifier = ">=3.0.4" },
 ]
 
 [[package]]
@@ -95,4 +97,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256 },
+]
+
+[[package]]
+name = "semver"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912 },
 ]


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD033) -->
<!-- trunk-ignore-all(markdownlint/MD041) -->

**Description**
- Runs once on app start
- Checks GitHub API for release tag and compares to `__version__.py`
- If newer, downloads release from `browser_download_url`
- No extraction steps yet (perfecting ui first)

It doesn't look quite the same as when downloading a rom, and since it occurs before anything else renders, I wonder if I'm missing some steps in the render pipeline that could otherwise make it look better. It does successfully download the latest `.muxapp` release if `__version__.py` is not present.