### PR TITLE
Add Nintendo/Xbox button layout option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .dist
 .test
 
+trunk.ps1

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,12 +2,12 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.11
+  version: 1.22.12
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.7
+      ref: v1.6.8
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -18,7 +18,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - checkov@3.2.394
+    - checkov@3.2.408
     - actionlint@1.7.7
     - taplo@0.9.3
     - yamllint@1.37.0
@@ -29,14 +29,14 @@ lint:
     - git-diff-check
     - isort@6.0.1
     - markdownlint@0.44.0
-    - osv-scanner@2.0.0
+    - osv-scanner@2.0.1
     - oxipng@9.1.4
     - prettier@3.5.3
-    - ruff@0.11.2
+    - ruff@0.11.6
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - svgo@3.3.2
-    - trufflehog@3.88.18
+    - trufflehog@3.88.25
   ignore:
     - linters: [oxipng]
       paths:

--- a/RomM/config.py
+++ b/RomM/config.py
@@ -15,7 +15,7 @@ BUTTON_CONFIGS = {
         {"key": "X", "btn": "X", "color": color_btn_x},  # North
         {"key": "Y", "btn": "Y", "color": color_btn_y},  # West
         {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
-        {"key": "R1", "btn": "R1", "color": color_btn_shoulder}, 
+        {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
     ],
     "xbox": [
         {"key": "B", "btn": "A", "color": color_btn_b},  # South
@@ -23,19 +23,22 @@ BUTTON_CONFIGS = {
         {"key": "Y", "btn": "X", "color": color_btn_y},  # West
         {"key": "X", "btn": "Y", "color": color_btn_x},  # North
         {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
-        {"key": "R1", "btn": "R1", "color": color_btn_shoulder}, 
+        {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
     ],
 }
 
 CONTROLLER_LAYOUT = os.getenv("CONTROLLER_LAYOUT", "nintendo")
 
+
 def get_controller_layout():
     return BUTTON_CONFIGS.get(CONTROLLER_LAYOUT, BUTTON_CONFIGS["nintendo"])
+
 
 def set_controller_layout(layout):
     global CONTROLLER_LAYOUT
     if layout in BUTTON_CONFIGS:
         CONTROLLER_LAYOUT = layout
+
 
 def save_controller_layout(env_path=".env"):
     layout = f"CONTROLLER_LAYOUT={CONTROLLER_LAYOUT}\n"

--- a/RomM/config.py
+++ b/RomM/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing import TypedDict
 
 color_btn_a = "#ad3c6b"
 color_btn_b = "#bb7200"
@@ -7,31 +8,55 @@ color_btn_x = "#3b80aa"
 color_btn_y = "#41aa3b"
 color_btn_shoulder = "#383838"
 
+
+class Button(TypedDict):
+    key: str
+    btn: str
+    color: str
+
+
+class ButtonConfig(TypedDict):
+    a: Button
+    b: Button
+    x: Button
+    y: Button
+    l1: Button
+    r1: Button
+
+
+class ButtonConfigs(TypedDict):
+    nintendo: ButtonConfig
+    xbox: ButtonConfig
+
+
 # Default button configurations
-BUTTON_CONFIGS = {
-    "nintendo": [
-        {"key": "A", "btn": "A", "color": color_btn_a},  # East
-        {"key": "B", "btn": "B", "color": color_btn_b},  # South
-        {"key": "X", "btn": "X", "color": color_btn_x},  # North
-        {"key": "Y", "btn": "Y", "color": color_btn_y},  # West
-        {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
-        {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
-    ],
-    "xbox": [
-        {"key": "B", "btn": "A", "color": color_btn_b},  # South
-        {"key": "A", "btn": "B", "color": color_btn_a},  # East
-        {"key": "Y", "btn": "X", "color": color_btn_y},  # West
-        {"key": "X", "btn": "Y", "color": color_btn_x},  # North
-        {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
-        {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
-    ],
+BUTTON_CONFIGS: ButtonConfigs = {
+    "nintendo": {
+        "a": {"key": "A", "btn": "A", "color": color_btn_a},  # East
+        "b": {"key": "B", "btn": "B", "color": color_btn_b},  # South
+        "x": {"key": "X", "btn": "X", "color": color_btn_x},  # North
+        "y": {"key": "Y", "btn": "Y", "color": color_btn_y},  # West
+        "l1": {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
+        "r1": {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
+    },
+    "xbox": {
+        "a": {"key": "A", "btn": "B", "color": color_btn_a},  # East
+        "b": {"key": "B", "btn": "A", "color": color_btn_b},  # South
+        "x": {"key": "X", "btn": "Y", "color": color_btn_x},  # North
+        "y": {"key": "Y", "btn": "X", "color": color_btn_y},  # West
+        "l1": {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
+        "r1": {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
+    },
 }
 
-CONTROLLER_LAYOUT = os.getenv("CONTROLLER_LAYOUT", "nintendo")
+CONTROLLER_LAYOUT = os.getenv("CONTROLLER_LAYOUT", "nintendo").lower()
 
 
-def get_controller_layout():
-    return BUTTON_CONFIGS.get(CONTROLLER_LAYOUT, BUTTON_CONFIGS["nintendo"])
+def get_controller_layout() -> ButtonConfig:
+    """Return the current controller layout configuration."""
+    if CONTROLLER_LAYOUT not in BUTTON_CONFIGS:
+        raise ValueError(f"Invalid controller layout: {CONTROLLER_LAYOUT}")
+    return BUTTON_CONFIGS[CONTROLLER_LAYOUT]  # trunk-ignore(mypy/literal-required)
 
 
 def set_controller_layout(layout: str):

--- a/RomM/config.py
+++ b/RomM/config.py
@@ -1,6 +1,5 @@
 import os
 import re
-from PIL import Image, ImageDraw, ImageFont
 
 color_btn_a = "#ad3c6b"
 color_btn_b = "#bb7200"

--- a/RomM/config.py
+++ b/RomM/config.py
@@ -40,10 +40,10 @@ BUTTON_CONFIGS: ButtonConfigs = {
         "r1": {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
     },
     "xbox": {
-        "a": {"key": "A", "btn": "B", "color": color_btn_a},  # East
-        "b": {"key": "B", "btn": "A", "color": color_btn_b},  # South
-        "x": {"key": "X", "btn": "Y", "color": color_btn_x},  # North
-        "y": {"key": "Y", "btn": "X", "color": color_btn_y},  # West
+        "a": {"key": "B", "btn": "A", "color": color_btn_a},  # East
+        "b": {"key": "A", "btn": "B", "color": color_btn_b},  # South
+        "x": {"key": "Y", "btn": "X", "color": color_btn_x},  # North
+        "y": {"key": "X", "btn": "Y", "color": color_btn_y},  # West
         "l1": {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
         "r1": {"key": "R1", "btn": "R1", "color": color_btn_shoulder},
     },

--- a/RomM/config.py
+++ b/RomM/config.py
@@ -1,0 +1,58 @@
+import os
+import re
+from PIL import Image, ImageDraw, ImageFont
+
+color_btn_a = "#ad3c6b"
+color_btn_b = "#bb7200"
+color_btn_x = "#3b80aa"
+color_btn_y = "#41aa3b"
+color_btn_shoulder = "#383838"
+
+# Default button configurations
+BUTTON_CONFIGS = {
+    "nintendo": [
+        {"key": "A", "btn": "A", "color": color_btn_a},  # East
+        {"key": "B", "btn": "B", "color": color_btn_b},  # South
+        {"key": "X", "btn": "X", "color": color_btn_x},  # North
+        {"key": "Y", "btn": "Y", "color": color_btn_y},  # West
+        {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
+        {"key": "R1", "btn": "R1", "color": color_btn_shoulder}, 
+    ],
+    "xbox": [
+        {"key": "B", "btn": "A", "color": color_btn_b},  # South
+        {"key": "A", "btn": "B", "color": color_btn_a},  # East
+        {"key": "Y", "btn": "X", "color": color_btn_y},  # West
+        {"key": "X", "btn": "Y", "color": color_btn_x},  # North
+        {"key": "L1", "btn": "L1", "color": color_btn_shoulder},
+        {"key": "R1", "btn": "R1", "color": color_btn_shoulder}, 
+    ],
+}
+
+CONTROLLER_LAYOUT = os.getenv("CONTROLLER_LAYOUT", "nintendo")
+
+def get_controller_layout():
+    return BUTTON_CONFIGS.get(CONTROLLER_LAYOUT, BUTTON_CONFIGS["nintendo"])
+
+def set_controller_layout(layout):
+    global CONTROLLER_LAYOUT
+    if layout in BUTTON_CONFIGS:
+        CONTROLLER_LAYOUT = layout
+
+def save_controller_layout(env_path=".env"):
+    layout = f"CONTROLLER_LAYOUT={CONTROLLER_LAYOUT}\n"
+
+    if os.path.exists(env_path):
+        with open(env_path, "r") as f:
+            lines = f.readlines()
+    else:
+        lines = []
+
+    for i, line in enumerate(lines):
+        if re.match(r"^\s*CONTROLLER_LAYOUT\s*=", line, re.IGNORECASE):
+            lines[i] = layout
+            break
+    else:
+        lines.append(layout)
+
+    with open(env_path, "w") as f:
+        f.writelines(lines)

--- a/RomM/config.py
+++ b/RomM/config.py
@@ -34,7 +34,7 @@ def get_controller_layout():
     return BUTTON_CONFIGS.get(CONTROLLER_LAYOUT, BUTTON_CONFIGS["nintendo"])
 
 
-def set_controller_layout(layout):
+def set_controller_layout(layout: str):
     global CONTROLLER_LAYOUT
     if layout in BUTTON_CONFIGS:
         CONTROLLER_LAYOUT = layout

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -32,8 +32,8 @@ def apply_pending_update() -> bool:
 # Check for update before initializing since it may overwrite our dependencies
 if not apply_pending_update():
     import sdl2
-    from dotenv import load_dotenv
     from config import set_controller_layout
+    from dotenv import load_dotenv
     from romm import RomM
 
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -34,7 +34,6 @@ if not apply_pending_update():
     import sdl2
     from config import set_controller_layout
     from dotenv import load_dotenv
-
     from romm import RomM
 
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -38,6 +38,8 @@ if not apply_pending_update():
 
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
     set_controller_layout(os.getenv("CONTROLLER_LAYOUT", "nintendo"))
+
+    # Set up logging
     log_file = os.environ.get("LOG_FILE", "./logs/log.txt")
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     sys.stdout = open(log_file, "w", buffering=1)

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -34,6 +34,7 @@ if not apply_pending_update():
     import sdl2
     from config import set_controller_layout
     from dotenv import load_dotenv
+
     from romm import RomM
 
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -33,10 +33,14 @@ def apply_pending_update() -> bool:
 if not apply_pending_update():
     import sdl2
     from dotenv import load_dotenv
+    from config import set_controller_layout
     from romm import RomM
 
     load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
-    sys.stdout = open(os.environ.get("LOG_FILE", "./logs/log.txt"), "w", buffering=1)
+    set_controller_layout(os.getenv("CONTROLLER_LAYOUT", "nintendo"))
+    log_file = os.environ.get("LOG_FILE", "./logs/log.txt")
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    sys.stdout = open(log_file, "w", buffering=1)
 
 
 def cleanup(romm: RomM, exit_code: int):

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -62,6 +62,7 @@ class RomM:
         self.max_n_collections = 10
         self.max_n_roms = 10
         self.buttons_config: List[ButtonConfig] = []
+        self.controller_layout = get_controller_layout()
 
         self.last_spinner_update = time.time()
         self.current_spinner_status = next(glyphs.spinner)
@@ -152,19 +153,19 @@ class RomM:
             )
             self.buttons_config = [
                 {
-                    "key": get_controller_layout()[0]["btn"],
+                    "key": self.controller_layout["a"]["btn"],
                     "label": "Yes",
-                    "color": get_controller_layout()[0]["color"],
+                    "color": self.controller_layout["a"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[1]["btn"],
+                    "key": self.controller_layout["b"]["btn"],
                     "label": "No",
-                    "color": get_controller_layout()[1]["color"],
+                    "color": self.controller_layout["b"]["color"],
                 },
             ]
             self.draw_buttons()
 
-            if self.input.key(get_controller_layout()[0]["key"]):
+            if self.input.key(self.controller_layout["a"]["key"]):
                 self.awaiting_input = False
                 self.ui.draw_clear()
                 if self.updater.download_update(self.download_url):
@@ -180,7 +181,7 @@ class RomM:
                 self.ui.render_to_screen()
                 sdl2.SDL_Delay(1000)
                 self.status.updating.clear()
-            elif self.input.key(get_controller_layout()[1]["key"]):
+            elif self.input.key(self.controller_layout["b"]["key"]):
                 self.awaiting_input = False
                 self.status.updating.clear()
                 self.ui.draw_clear()
@@ -207,7 +208,7 @@ class RomM:
             if self.status.extracting_rom:
                 self.ui.draw_loader(
                     self.status.extracted_percent,
-                    color=get_controller_layout()[1]["color"],
+                    color=self.controller_layout["b"]["color"],
                 )
                 self.ui.draw_log(
                     text_line_1=f"{self.status.downloading_rom_position}/{len(self.status.download_queue)} | {self.status.extracted_percent:.2f}% | Extracting {self.status.downloading_rom.name}",
@@ -224,37 +225,37 @@ class RomM:
         elif not self.status.valid_host:
             self.ui.draw_log(
                 text_line_1=f"Error: Can't connect to host {self.api.host}",
-                text_color=get_controller_layout()[0]["color"],
+                text_color=self.controller_layout["a"]["color"],
             )
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
                 text_line_1="Error: Permission denied",
-                text_color=get_controller_layout()[0]["color"],
+                text_color=self.controller_layout["a"]["color"],
             )
             self.status.valid_credentials = True
         else:
             self.buttons_config = [
                 {
-                    "key": get_controller_layout()[0]["btn"],
+                    "key": self.controller_layout["a"]["btn"],
                     "label": "Select",
-                    "color": get_controller_layout()[0]["color"],
+                    "color": self.controller_layout["a"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[3]["btn"],
+                    "key": self.controller_layout["y"]["btn"],
                     "label": "Refresh",
-                    "color": get_controller_layout()[3]["color"],
+                    "color": self.controller_layout["y"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[2]["btn"],
+                    "key": self.controller_layout["x"]["btn"],
                     "label": "Collections",
-                    "color": get_controller_layout()[2]["color"],
+                    "color": self.controller_layout["x"]["color"],
                 },
             ]
             self.draw_buttons()
 
     def _update_platforms_view(self):
-        if self.input.key(get_controller_layout()[0]["key"]):
+        if self.input.key(self.controller_layout["a"]["key"]):
             if self.status.roms_ready.is_set() and len(self.status.platforms) > 0:
                 self.status.roms_ready.clear()
                 self.status.roms = []
@@ -263,11 +264,11 @@ class RomM:
                 ]
                 self.status.current_view = View.ROMS
                 threading.Thread(target=self.api.fetch_roms).start()
-        elif self.input.key(get_controller_layout()[3]["key"]):
+        elif self.input.key(self.controller_layout["y"]["key"]):
             if self.status.platforms_ready.is_set():
                 self.status.platforms_ready.clear()
                 threading.Thread(target=self.api.fetch_platforms).start()
-        elif self.input.key(get_controller_layout()[2]["key"]):
+        elif self.input.key(self.controller_layout["x"]["key"]):
             self.status.current_view = View.COLLECTIONS
         elif self.input.key("START"):
             self.status.show_contextual_menu = not self.status.show_contextual_menu
@@ -300,7 +301,7 @@ class RomM:
                 self.collections_selected_position,
                 self.max_n_collections,
                 self.status.collections,
-                fill=get_controller_layout()[1]["color"],
+                fill=self.controller_layout["b"]["color"],
             )
         if not self.status.collections_ready.is_set():
             current_time = time.time()
@@ -314,7 +315,7 @@ class RomM:
             if self.status.extracting_rom:
                 self.ui.draw_loader(
                     self.status.extracted_percent,
-                    color=get_controller_layout()[1]["color"],
+                    color=self.controller_layout["b"]["color"],
                 )
                 self.ui.draw_log(
                     text_line_1=f"{self.status.downloading_rom_position}/{len(self.status.download_queue)} | {self.status.extracted_percent:.2f}% | Extracting {self.status.downloading_rom.name}",
@@ -331,37 +332,37 @@ class RomM:
         elif not self.status.valid_host:
             self.ui.draw_log(
                 text_line_1=f"Error: Can't connect to host {self.api.host}",
-                text_color=get_controller_layout()[0]["color"],
+                text_color=self.controller_layout["a"]["color"],
             )
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
                 text_line_1="Error: Permission denied",
-                text_color=get_controller_layout()[0]["color"],
+                text_color=self.controller_layout["a"]["color"],
             )
             self.status.valid_credentials = True
         else:
             self.buttons_config = [
                 {
-                    "key": get_controller_layout()[0]["btn"],
+                    "key": self.controller_layout["a"]["btn"],
                     "label": "Select",
-                    "color": get_controller_layout()[0]["color"],
+                    "color": self.controller_layout["a"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[3]["btn"],
+                    "key": self.controller_layout["y"]["btn"],
                     "label": "Refresh",
-                    "color": get_controller_layout()[3]["color"],
+                    "color": self.controller_layout["y"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[2]["btn"],
+                    "key": self.controller_layout["x"]["btn"],
                     "label": "Platforms",
-                    "color": get_controller_layout()[2]["color"],
+                    "color": self.controller_layout["x"]["color"],
                 },
             ]
             self.draw_buttons()
 
     def _update_collections_view(self):
-        if self.input.key(get_controller_layout()[0]["key"]):
+        if self.input.key(self.controller_layout["a"]["key"]):
             if self.status.roms_ready.is_set() and len(self.status.collections) > 0:
                 self.status.roms_ready.clear()
                 self.status.roms = []
@@ -374,11 +375,11 @@ class RomM:
                     self.status.selected_collection = selected_collection
                 self.status.current_view = View.ROMS
                 threading.Thread(target=self.api.fetch_roms).start()
-        elif self.input.key(get_controller_layout()[3]["key"]):
+        elif self.input.key(self.controller_layout["y"]["key"]):
             if self.status.collections_ready.is_set():
                 self.status.collections_ready.clear()
                 threading.Thread(target=self.api.fetch_collections).start()
-        elif self.input.key(get_controller_layout()[2]["key"]):
+        elif self.input.key(self.controller_layout["x"]["key"]):
             self.status.current_view = View.PLATFORMS
         elif self.input.key("START"):
             self.status.show_contextual_menu = not self.status.show_contextual_menu
@@ -404,23 +405,23 @@ class RomM:
     def _render_roms_view(self):
         if len(self.status.roms) == 0 and self.status.roms_ready.is_set():
             header_text = "No ROMs available"
-            header_color = get_controller_layout()[0]["color"]
+            header_color = self.controller_layout["a"]["color"]
             prepend_platform_slug = False
         elif self.status.selected_platform:
             header_text = self.status.platforms[
                 self.platforms_selected_position
             ].display_name
-            header_color = get_controller_layout()[0]["color"]
+            header_color = self.controller_layout["a"]["color"]
             prepend_platform_slug = False
         elif self.status.selected_collection or self.status.selected_virtual_collection:
             header_text = self.status.collections[
                 self.collections_selected_position
             ].name
-            header_color = get_controller_layout()[1]["color"]
+            header_color = self.controller_layout["b"]["color"]
             prepend_platform_slug = True
         else:
             header_text = "ROMs"
-            header_color = get_controller_layout()[0]["color"]
+            header_color = self.controller_layout["a"]["color"]
             prepend_platform_slug = False
 
         total_pages = (
@@ -462,7 +463,7 @@ class RomM:
             if self.status.extracting_rom:
                 self.ui.draw_loader(
                     self.status.extracted_percent,
-                    color=get_controller_layout()[1]["color"],
+                    color=self.controller_layout["b"]["color"],
                 )
                 self.ui.draw_log(
                     text_line_1=f"{self.status.downloading_rom_position}/{len(self.status.download_queue)} | {self.status.extracted_percent:.2f}% | Extracting {self.status.downloading_rom.name}",
@@ -479,39 +480,39 @@ class RomM:
         elif not self.status.valid_host:
             self.ui.draw_log(
                 text_line_1=f"Error: Can't connect to host {self.api.host}",
-                text_color=get_controller_layout()[0]["color"],
+                text_color=self.controller_layout["a"]["color"],
             )
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
                 text_line_1="Error: Permission denied",
-                text_color=get_controller_layout()[0]["color"],
+                text_color=self.controller_layout["a"]["color"],
             )
             self.status.valid_credentials = True
         else:
             self.buttons_config = [
                 {
-                    "key": get_controller_layout()[0]["btn"],
+                    "key": self.controller_layout["a"]["btn"],
                     "label": "Download",
-                    "color": get_controller_layout()[0]["color"],
+                    "color": self.controller_layout["a"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[1]["btn"],
+                    "key": self.controller_layout["b"]["btn"],
                     "label": "Back",
-                    "color": get_controller_layout()[1]["color"],
+                    "color": self.controller_layout["b"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[3]["btn"],
+                    "key": self.controller_layout["y"]["btn"],
                     "label": "Refresh",
-                    "color": get_controller_layout()[3]["color"],
+                    "color": self.controller_layout["y"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[2]["btn"],
+                    "key": self.controller_layout["x"]["btn"],
                     "label": f"Filter:{self.status.current_filter}",
-                    "color": get_controller_layout()[2]["color"],
+                    "color": self.controller_layout["x"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[4]["btn"],
+                    "key": self.controller_layout["l1"]["btn"],
                     "label": (
                         "Deselect rom"
                         if (
@@ -521,23 +522,23 @@ class RomM:
                         )
                         else "Select rom"
                     ),
-                    "color": get_controller_layout()[4]["color"],
+                    "color": self.controller_layout["l1"]["color"],
                 },
                 {
-                    "key": get_controller_layout()[5]["btn"],
+                    "key": self.controller_layout["r1"]["btn"],
                     "label": (
                         "Deselect all"
                         if len(self.status.multi_selected_roms)
                         == len(self.status.roms_to_show)
                         else "Select all"
                     ),
-                    "color": get_controller_layout()[5]["color"],
+                    "color": self.controller_layout["r1"]["color"],
                 },
             ]
             self.draw_buttons()
 
     def _update_roms_view(self):
-        if self.input.key(get_controller_layout()[0]["key"]):
+        if self.input.key(self.controller_layout["a"]["key"]):
             if (
                 self.status.roms_ready.is_set()
                 and self.status.download_rom_ready.is_set()
@@ -551,7 +552,7 @@ class RomM:
                 self.status.download_queue = self.status.multi_selected_roms
                 self.status.abort_download.clear()
                 threading.Thread(target=self.api.download_rom).start()
-        elif self.input.key(get_controller_layout()[1]["key"]):
+        elif self.input.key(self.controller_layout["b"]["key"]):
             if self.status.selected_platform:
                 self.status.current_view = View.PLATFORMS
                 self.status.selected_platform = None
@@ -566,20 +567,20 @@ class RomM:
             self.status.reset_roms_list()
             self.roms_selected_position = 0
             self.status.multi_selected_roms = []
-        elif self.input.key(get_controller_layout()[3]["key"]):
+        elif self.input.key(self.controller_layout["y"]["key"]):
             if self.status.roms_ready.is_set():
                 self.status.roms_ready.clear()
                 threading.Thread(target=self.api.fetch_roms).start()
                 self.status.multi_selected_roms = []
-        elif self.input.key(get_controller_layout()[2]["key"]):
+        elif self.input.key(self.controller_layout["x"]["key"]):
             self.status.current_filter = next(self.status.filters)
             self.roms_selected_position = 0
-        elif self.input.key(get_controller_layout()[5]["key"]):
+        elif self.input.key(self.controller_layout["r1"]["key"]):
             if len(self.status.multi_selected_roms) == len(self.status.roms_to_show):
                 self.status.multi_selected_roms = []
             else:
                 self.status.multi_selected_roms = self.status.roms_to_show.copy()
-        elif self.input.key(get_controller_layout()[4]["key"]):
+        elif self.input.key(self.controller_layout["l1"]["key"]):
             if (
                 self.status.download_rom_ready.is_set()
                 and len(self.status.roms_to_show) > 0
@@ -652,13 +653,13 @@ class RomM:
             )
 
     def _update_contextual_menu(self):
-        if self.input.key(get_controller_layout()[0]["key"]):
+        if self.input.key(self.controller_layout["a"]["key"]):
             if len(self.contextual_menu_options) > 0:
                 self.contextual_menu_options[self.contextual_menu_selected_position][
                     2
                 ]()
                 self.status.show_contextual_menu = False
-        elif self.input.key(get_controller_layout()[1]["key"]):
+        elif self.input.key(self.controller_layout["b"]["key"]):
             self.status.show_contextual_menu = False
             self.contextual_menu_options = []
         else:
@@ -727,7 +728,7 @@ class RomM:
         )
 
     def _update_start_menu(self):
-        if self.input.key(get_controller_layout()[0]["key"]):
+        if self.input.key(self.controller_layout["a"]["key"]):
             selected_pos = self.start_menu_selected_position
             if selected_pos == self.start_menu_options[0][1]:
                 self.status.abort_download.set()
@@ -741,7 +742,7 @@ class RomM:
                 new_layout = layouts[(current_idx + 1) % len(layouts)]
                 set_controller_layout(new_layout)
                 self.ui.layout_name = new_layout
-                self.ui.current_layout = get_controller_layout()
+                self.controller_layout = get_controller_layout()
                 save_controller_layout()
                 self.status.show_start_menu = False
                 self.ui.draw_clear()
@@ -757,7 +758,7 @@ class RomM:
             elif selected_pos == self.start_menu_options[3][1]:
                 self.running = False
                 self.status.show_start_menu = False
-        elif self.input.key(get_controller_layout()[1]["key"]):
+        elif self.input.key(self.controller_layout["b"]["key"]):
             self.status.show_start_menu = not self.status.show_start_menu
         else:
             n_selectable_options = 4 if self.fs._sd2_roms_storage_path else 3
@@ -805,37 +806,37 @@ class RomM:
             self.ui.draw_header(self.api.host, self.api.username)
 
         if not self.status.valid_host:
-            if self.input.key(get_controller_layout()[3]["key"]):
+            if self.input.key(self.controller_layout["y"]["key"]):
                 if self.status.platforms_ready.is_set():
                     self.status.platforms_ready.clear()
                     threading.Thread(target=self.api.fetch_platforms).start()
             self.ui.button_circle(
                 (20, 460),
-                get_controller_layout()[3]["btn"],
+                self.controller_layout["y"]["btn"],
                 "Refresh",
-                color=get_controller_layout()[3]["color"],
+                color=self.controller_layout["y"]["color"],
             )
             self.ui.draw_text(
                 (self.ui.screen_width / 2, self.ui.screen_height / 2),
                 f"Error: Can't connect to host\n{self.api.host}",
-                color=get_controller_layout()[0]["color"],
+                color=self.controller_layout["a"]["color"],
                 anchor="mm",
             )
         elif not self.status.valid_credentials:
-            if self.input.key(get_controller_layout()[3]["key"]):
+            if self.input.key(self.controller_layout["y"]["key"]):
                 if self.status.platforms_ready.is_set():
                     self.status.platforms_ready.clear()
                     threading.Thread(target=self.api.fetch_platforms).start()
             self.ui.button_circle(
                 (20, 460),
-                get_controller_layout()[3]["btn"],
+                self.controller_layout["y"]["btn"],
                 "Refresh",
-                color=get_controller_layout()[3]["color"],
+                color=self.controller_layout["y"]["color"],
             )
             self.ui.draw_text(
                 (self.ui.screen_width / 2, self.ui.screen_height / 2),
                 "Error: Permission denied",
-                color=get_controller_layout()[0]["color"],
+                color=self.controller_layout["a"]["color"],
                 anchor="mm",
             )
         else:

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -12,19 +12,25 @@ else:
     version = "unknown"
 
 from api import API
+from config import (
+    BUTTON_CONFIGS,
+    get_controller_layout,
+    set_controller_layout,
+    save_controller_layout,
+    color_btn_a,
+    color_btn_b,
+    color_btn_x,
+    color_btn_y,
+    color_btn_shoulder,
+)
 from filesystem import Filesystem
 from glyps import glyphs
 from input import Input
 from status import Filter, Status, View
 from ui import (
     UserInterface,
-    color_btn_a,
-    color_btn_b,
-    color_btn_shoulder,
-    color_btn_x,
-    color_btn_y,
+    color_row_bg,
     color_menu_bg,
-    color_sel,
     color_text,
 )
 from update import Update
@@ -33,6 +39,7 @@ from update import Update
 class StartMenuOptions:
     ABORT_DOWNLOAD = f"{glyphs.abort} Abort downloads"
     SD_SWITCH = f"{glyphs.microsd} Switch SD"
+    TOGGLE_LAYOUT = f"{glyphs.user} Toggle button layout"
     EXIT = f"{glyphs.exit} Exit"
 
 
@@ -58,7 +65,7 @@ class RomM:
         self.max_n_platforms = 10
         self.max_n_collections = 10
         self.max_n_roms = 10
-        self.buttons_config: list[dict[str, str]] = []
+        self.buttons_config = []
 
         self.last_spinner_update = time.time()
         self.current_spinner_status = next(glyphs.spinner)
@@ -72,7 +79,8 @@ class RomM:
         self.start_menu_options = [
             (StartMenuOptions.ABORT_DOWNLOAD, 0),
             (StartMenuOptions.SD_SWITCH, 1 if self.fs._sd2_roms_storage_path else -1),
-            (StartMenuOptions.EXIT, 2 if self.fs._sd2_roms_storage_path else 1),
+            (StartMenuOptions.TOGGLE_LAYOUT, 2 if self.fs._sd2_roms_storage_path else 1),
+            (StartMenuOptions.EXIT, 3 if self.fs._sd2_roms_storage_path else 2),
         ]
 
     def draw_buttons(self):
@@ -144,12 +152,20 @@ class RomM:
                 anchor="mm",
             )
             self.buttons_config = [
-                {"key": "A", "label": "Yes", "color": color_btn_a},
-                {"key": "B", "label": "No", "color": color_btn_b},
+                {
+                    "key": get_controller_layout()[0]["btn"],
+                    "label": "Yes",
+                    "color": get_controller_layout()[0]["color"],
+                },
+                {
+                    "key": get_controller_layout()[1]["btn"],
+                    "label": "No",
+                    "color": get_controller_layout()[1]["color"],
+                },
             ]
             self.draw_buttons()
 
-            if self.input.key("A"):
+            if self.input.key(get_controller_layout()[0]["key"]):
                 self.awaiting_input = False
                 self.ui.draw_clear()
                 if self.updater.download_update(self.download_url):
@@ -165,7 +181,7 @@ class RomM:
                 self.ui.render_to_screen()
                 sdl2.SDL_Delay(1000)
                 self.status.updating.clear()
-            elif self.input.key("B"):
+            elif self.input.key(get_controller_layout()[1]["key"]):
                 self.awaiting_input = False
                 self.status.updating.clear()
                 self.ui.draw_clear()
@@ -190,7 +206,10 @@ class RomM:
             )
         elif not self.status.download_rom_ready.is_set():
             if self.status.extracting_rom:
-                self.ui.draw_loader(self.status.extracted_percent, color=color_btn_b)
+                self.ui.draw_loader(
+                    self.status.extracted_percent, 
+                    color=get_controller_layout()[1]["color"],
+                )
                 self.ui.draw_log(
                     text_line_1=f"{self.status.downloading_rom_position}/{len(self.status.download_queue)} | {self.status.extracted_percent:.2f}% | Extracting {self.status.downloading_rom.name}",
                     text_line_2=f"({self.status.downloading_rom.fs_name})",
@@ -206,24 +225,37 @@ class RomM:
         elif not self.status.valid_host:
             self.ui.draw_log(
                 text_line_1=f"Error: Can't connect to host {self.api.host}",
-                text_color=color_btn_a,
+                text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
-                text_line_1="Error: Permission denied", text_color=color_btn_a
+                text_line_1="Error: Permission denied", 
+                text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_credentials = True
         else:
             self.buttons_config = [
-                {"key": "A", "label": "Select", "color": color_btn_a},
-                {"key": "Y", "label": "Refresh", "color": color_btn_y},
-                {"key": "X", "label": "Collections", "color": color_btn_x},
+                {
+                    "key": get_controller_layout()[0]["btn"],
+                    "label": "Select",
+                    "color": get_controller_layout()[0]["color"],
+                },
+                {
+                    "key": get_controller_layout()[3]["btn"],
+                    "label": "Refresh",
+                    "color": get_controller_layout()[3]["color"],
+                },
+                {
+                    "key": get_controller_layout()[2]["btn"],
+                    "label": "Collections",
+                    "color": get_controller_layout()[2]["color"],
+                },
             ]
             self.draw_buttons()
 
     def _update_platforms_view(self):
-        if self.input.key("A"):
+        if self.input.key(get_controller_layout()[0]["key"]):
             if self.status.roms_ready.is_set() and len(self.status.platforms) > 0:
                 self.status.roms_ready.clear()
                 self.status.roms = []
@@ -232,11 +264,11 @@ class RomM:
                 ]
                 self.status.current_view = View.ROMS
                 threading.Thread(target=self.api.fetch_roms).start()
-        elif self.input.key("Y"):
+        elif self.input.key(get_controller_layout()[3]["key"]):
             if self.status.platforms_ready.is_set():
                 self.status.platforms_ready.clear()
                 threading.Thread(target=self.api.fetch_platforms).start()
-        elif self.input.key("X"):
+        elif self.input.key(get_controller_layout()[2]["key"]):
             self.status.current_view = View.COLLECTIONS
         elif self.input.key("START"):
             self.status.show_contextual_menu = not self.status.show_contextual_menu
@@ -269,7 +301,7 @@ class RomM:
                 self.collections_selected_position,
                 self.max_n_collections,
                 self.status.collections,
-                fill=color_btn_b,
+                fill=get_controller_layout()[1]["color"],
             )
         if not self.status.collections_ready.is_set():
             current_time = time.time()
@@ -281,7 +313,10 @@ class RomM:
             )
         elif not self.status.download_rom_ready.is_set():
             if self.status.extracting_rom:
-                self.ui.draw_loader(self.status.extracted_percent, color=color_btn_b)
+                self.ui.draw_loader(
+                    self.status.extracted_percent, 
+                    color=get_controller_layout()[1]["color"],
+                )
                 self.ui.draw_log(
                     text_line_1=f"{self.status.downloading_rom_position}/{len(self.status.download_queue)} | {self.status.extracted_percent:.2f}% | Extracting {self.status.downloading_rom.name}",
                     text_line_2=f"({self.status.downloading_rom.fs_name})",
@@ -297,24 +332,37 @@ class RomM:
         elif not self.status.valid_host:
             self.ui.draw_log(
                 text_line_1=f"Error: Can't connect to host {self.api.host}",
-                text_color=color_btn_a,
+                text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
-                text_line_1="Error: Permission denied", text_color=color_btn_a
+                text_line_1="Error: Permission denied", 
+                text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_credentials = True
         else:
             self.buttons_config = [
-                {"key": "A", "label": "Select", "color": color_btn_a},
-                {"key": "Y", "label": "Refresh", "color": color_btn_y},
-                {"key": "X", "label": "Platforms", "color": color_btn_x},
+                {
+                    "key": get_controller_layout()[0]["btn"],
+                    "label": "Select",
+                    "color": get_controller_layout()[0]["color"],
+                },
+                {
+                    "key": get_controller_layout()[3]["btn"],
+                    "label": "Refresh",
+                    "color": get_controller_layout()[3]["color"],
+                },
+                {
+                    "key": get_controller_layout()[2]["btn"],
+                    "label": "Platforms",
+                    "color": get_controller_layout()[2]["color"],
+                },
             ]
             self.draw_buttons()
 
     def _update_collections_view(self):
-        if self.input.key("A"):
+        if self.input.key(get_controller_layout()[0]["key"]):
             if self.status.roms_ready.is_set() and len(self.status.collections) > 0:
                 self.status.roms_ready.clear()
                 self.status.roms = []
@@ -327,11 +375,11 @@ class RomM:
                     self.status.selected_collection = selected_collection
                 self.status.current_view = View.ROMS
                 threading.Thread(target=self.api.fetch_roms).start()
-        elif self.input.key("Y"):
+        elif self.input.key(get_controller_layout()[3]["key"]):
             if self.status.collections_ready.is_set():
                 self.status.collections_ready.clear()
                 threading.Thread(target=self.api.fetch_collections).start()
-        elif self.input.key("X"):
+        elif self.input.key(get_controller_layout()[2]["key"]):
             self.status.current_view = View.PLATFORMS
         elif self.input.key("START"):
             self.status.show_contextual_menu = not self.status.show_contextual_menu
@@ -357,23 +405,23 @@ class RomM:
     def _render_roms_view(self):
         if len(self.status.roms) == 0 and self.status.roms_ready.is_set():
             header_text = "No ROMs available"
-            header_color = color_btn_a
+            header_color = get_controller_layout()[0]["color"]
             prepend_platform_slug = False
         elif self.status.selected_platform:
             header_text = self.status.platforms[
                 self.platforms_selected_position
             ].display_name
-            header_color = color_sel
+            header_color = get_controller_layout()[0]["color"]
             prepend_platform_slug = False
         elif self.status.selected_collection or self.status.selected_virtual_collection:
             header_text = self.status.collections[
                 self.collections_selected_position
             ].name
-            header_color = color_btn_b
+            header_color = get_controller_layout()[1]["color"]
             prepend_platform_slug = True
         else:
             header_text = "ROMs"
-            header_color = color_sel
+            header_color = color_btn_a
             prepend_platform_slug = False
 
         total_pages = (
@@ -413,7 +461,10 @@ class RomM:
             self.ui.draw_log(text_line_1=f"{self.current_spinner_status} Fetching roms")
         elif not self.status.download_rom_ready.is_set():
             if self.status.extracting_rom:
-                self.ui.draw_loader(self.status.extracted_percent, color=color_btn_b)
+                self.ui.draw_loader(
+                    self.status.extracted_percent, 
+                    color=get_controller_layout()[1]["color"],
+                )
                 self.ui.draw_log(
                     text_line_1=f"{self.status.downloading_rom_position}/{len(self.status.download_queue)} | {self.status.extracted_percent:.2f}% | Extracting {self.status.downloading_rom.name}",
                     text_line_2=f"({self.status.downloading_rom.fs_name})",
@@ -429,26 +480,39 @@ class RomM:
         elif not self.status.valid_host:
             self.ui.draw_log(
                 text_line_1=f"Error: Can't connect to host {self.api.host}",
-                text_color=color_btn_a,
+                text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
-                text_line_1="Error: Permission denied", text_color=color_btn_a
+                text_line_1="Error: Permission denied", 
+                text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_credentials = True
         else:
             self.buttons_config = [
-                {"key": "A", "label": "Download", "color": color_btn_a},
-                {"key": "B", "label": "Back", "color": color_btn_b},
-                {"key": "Y", "label": "Refresh", "color": color_btn_y},
                 {
-                    "key": "X",
-                    "label": f"Filter:{self.status.current_filter}",
-                    "color": color_btn_x,
+                    "key": get_controller_layout()[0]["btn"],
+                    "label": "Download",
+                    "color": get_controller_layout()[0]["color"],
                 },
                 {
-                    "key": "L1",
+                    "key": get_controller_layout()[1]["btn"],
+                    "label": "Back",
+                    "color": get_controller_layout()[1]["color"],
+                },
+                {
+                    "key": get_controller_layout()[3]["btn"],
+                    "label": "Refresh",
+                    "color": get_controller_layout()[3]["color"],
+                },
+                {
+                    "key": get_controller_layout()[2]["btn"],
+                    "label": f"Filter:{self.status.current_filter}",
+                    "color": get_controller_layout()[2]["color"],
+                },
+                {
+                    "key": get_controller_layout()[4]["btn"],
                     "label": (
                         "Deselect rom"
                         if (
@@ -458,23 +522,23 @@ class RomM:
                         )
                         else "Select rom"
                     ),
-                    "color": color_btn_shoulder,
+                    "color": get_controller_layout()[4]["color"],
                 },
                 {
-                    "key": "R1",
+                    "key": get_controller_layout()[5]["btn"],
                     "label": (
                         "Deselect all"
                         if len(self.status.multi_selected_roms)
                         == len(self.status.roms_to_show)
                         else "Select all"
                     ),
-                    "color": color_btn_shoulder,
+                    "color": get_controller_layout()[5]["color"],
                 },
             ]
             self.draw_buttons()
 
     def _update_roms_view(self):
-        if self.input.key("A"):
+        if self.input.key(get_controller_layout()[0]["key"]):
             if (
                 self.status.roms_ready.is_set()
                 and self.status.download_rom_ready.is_set()
@@ -488,7 +552,7 @@ class RomM:
                 self.status.download_queue = self.status.multi_selected_roms
                 self.status.abort_download.clear()
                 threading.Thread(target=self.api.download_rom).start()
-        elif self.input.key("B"):
+        elif self.input.key(get_controller_layout()[1]["key"]):
             if self.status.selected_platform:
                 self.status.current_view = View.PLATFORMS
                 self.status.selected_platform = None
@@ -503,20 +567,20 @@ class RomM:
             self.status.reset_roms_list()
             self.roms_selected_position = 0
             self.status.multi_selected_roms = []
-        elif self.input.key("Y"):
+        elif self.input.key(get_controller_layout()[3]["key"]):
             if self.status.roms_ready.is_set():
                 self.status.roms_ready.clear()
                 threading.Thread(target=self.api.fetch_roms).start()
                 self.status.multi_selected_roms = []
-        elif self.input.key("X"):
+        elif self.input.key(get_controller_layout()[2]["key"]):
             self.status.current_filter = next(self.status.filters)
             self.roms_selected_position = 0
-        elif self.input.key("R1"):
+        elif self.input.key(get_controller_layout()[5]["key"]):
             if len(self.status.multi_selected_roms) == len(self.status.roms_to_show):
                 self.status.multi_selected_roms = []
             else:
                 self.status.multi_selected_roms = self.status.roms_to_show.copy()
-        elif self.input.key("L1"):
+        elif self.input.key(get_controller_layout()[4]["key"]):
             if (
                 self.status.download_rom_ready.is_set()
                 and len(self.status.roms_to_show) > 0
@@ -589,13 +653,13 @@ class RomM:
             )
 
     def _update_contextual_menu(self):
-        if self.input.key("A"):
+        if self.input.key(get_controller_layout()[0]["key"]):
             if len(self.contextual_menu_options) > 0:
                 self.contextual_menu_options[self.contextual_menu_selected_position][
                     2
                 ]()
                 self.status.show_contextual_menu = False
-        elif self.input.key("B"):
+        elif self.input.key(get_controller_layout()[1]["key"]):
             self.status.show_contextual_menu = False
             self.contextual_menu_options = []
         else:
@@ -609,13 +673,20 @@ class RomM:
         pos = [self.ui.screen_width / 3, self.ui.screen_height / 3]
         padding = 5
         width = 200
-        n_selectable_options = 3 if self.fs._sd2_roms_storage_path else 2
+        n_selectable_options = 4 if self.fs._sd2_roms_storage_path else 3
         option_height = 24
         gap = 3
         title = "Main menu"
         title_x_adjustment = 35
         version_x_adjustment = 50 / 6 * (len(version) + 2)
         version_height = 20
+        layouts = list(BUTTON_CONFIGS.keys())
+        current_idx = layouts.index(self.ui.layout_name)
+        next_layout = layouts[(current_idx + 1) % len(layouts)]
+        self.start_menu_options[2] = (
+            f"{glyphs.user} Toggle layout: {next_layout.capitalize()}",
+            self.start_menu_options[2][1]
+        )
         self.ui.draw_menu_background(
             pos,
             width,
@@ -657,20 +728,40 @@ class RomM:
         )
 
     def _update_start_menu(self):
-        if self.input.key("A"):
-            if self.start_menu_selected_position == self.start_menu_options[0][1]:
+        if self.input.key(get_controller_layout()[0]["key"]):
+            selected_pos = self.start_menu_selected_position
+            if selected_pos == self.start_menu_options[0][1]:
                 self.status.abort_download.set()
                 self.status.show_start_menu = False
-            elif self.start_menu_selected_position == self.start_menu_options[1][1]:
+            elif selected_pos == self.start_menu_options[1][1]:
                 self.fs.switch_sd_storage()
                 self.status.show_start_menu = False
-            elif self.start_menu_selected_position == self.start_menu_options[2][1]:
+            elif selected_pos == self.start_menu_options[2][1]:
+                layouts = list(BUTTON_CONFIGS.keys())
+                current_idx = layouts.index(self.ui.layout_name)
+                new_layout = layouts[(current_idx + 1) % len(layouts)]
+                set_controller_layout(new_layout)
+                self.ui.layout_name = new_layout
+                self.ui.current_layout = get_controller_layout()
+                save_controller_layout()
+                self.status.show_start_menu = False
+                self.ui.draw_clear()
+                if self.status.current_view == View.PLATFORMS:
+                    self._render_platforms_view()
+                elif self.status.current_view == View.COLLECTIONS:
+                    self._render_collections_view()
+                elif self.status.current_view == View.ROMS:
+                    self._render_roms_view()
+                else:
+                    self._render_platforms_view()
+                self.ui.render_to_screen()
+            elif selected_pos == self.start_menu_options[3][1]:
                 self.running = False
                 self.status.show_start_menu = False
-        elif self.input.key("B"):
+        elif self.input.key(get_controller_layout()[1]["key"]):
             self.status.show_start_menu = not self.status.show_start_menu
         else:
-            n_selectable_options = 3 if self.fs._sd2_roms_storage_path else 2
+            n_selectable_options = 4 if self.fs._sd2_roms_storage_path else 3
             self.start_menu_selected_position = self.input.handle_navigation(
                 self.start_menu_selected_position,
                 n_selectable_options,
@@ -715,27 +806,37 @@ class RomM:
             self.ui.draw_header(self.api.host, self.api.username)
 
         if not self.status.valid_host:
-            if self.input.key("Y"):
+            if self.input.key(get_controller_layout()[3]["key"]):
                 if self.status.platforms_ready.is_set():
                     self.status.platforms_ready.clear()
                     threading.Thread(target=self.api.fetch_platforms).start()
-            self.ui.button_circle((20, 460), "Y", "Refresh", color=color_btn_y)
+            self.ui.button_circle(
+                (20, 460),
+                get_controller_layout()[3]["btn"],
+                "Refresh",
+                color=get_controller_layout()[3]["color"],
+            )
             self.ui.draw_text(
                 (self.ui.screen_width / 2, self.ui.screen_height / 2),
                 f"Error: Can't connect to host\n{self.api.host}",
-                color=color_btn_a,
+                color=get_controller_layout()[0]["color"],
                 anchor="mm",
             )
         elif not self.status.valid_credentials:
-            if self.input.key("Y"):
+            if self.input.key(get_controller_layout()[3]["key"]):
                 if self.status.platforms_ready.is_set():
                     self.status.platforms_ready.clear()
                     threading.Thread(target=self.api.fetch_platforms).start()
-            self.ui.button_circle((20, 460), "Y", "Refresh", color=color_btn_y)
+            self.ui.button_circle(
+                (20, 460),
+                get_controller_layout()[3]["btn"],
+                "Refresh",
+                color=get_controller_layout()[3]["color"],
+            )
             self.ui.draw_text(
                 (self.ui.screen_width / 2, self.ui.screen_height / 2),
                 "Error: Permission denied",
-                color=color_btn_a,
+                color=get_controller_layout()[0]["color"],
                 anchor="mm",
             )
         else:

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -1,7 +1,7 @@
 import os
 import threading
 import time
-from typing import Any, Tuple, List, Dict
+from typing import Any, Dict, List, Tuple
 
 import sdl2
 import sdl2.ext
@@ -15,8 +15,8 @@ from api import API
 from config import (
     BUTTON_CONFIGS,
     get_controller_layout,
-    set_controller_layout,
     save_controller_layout,
+    set_controller_layout,
 )
 from filesystem import Filesystem
 from glyps import glyphs
@@ -75,7 +75,10 @@ class RomM:
         self.start_menu_options = [
             (StartMenuOptions.ABORT_DOWNLOAD, 0),
             (StartMenuOptions.SD_SWITCH, 1 if self.fs._sd2_roms_storage_path else -1),
-            (StartMenuOptions.TOGGLE_LAYOUT, 2 if self.fs._sd2_roms_storage_path else 1),
+            (
+                StartMenuOptions.TOGGLE_LAYOUT,
+                2 if self.fs._sd2_roms_storage_path else 1,
+            ),
             (StartMenuOptions.EXIT, 3 if self.fs._sd2_roms_storage_path else 2),
         ]
 
@@ -203,7 +206,7 @@ class RomM:
         elif not self.status.download_rom_ready.is_set():
             if self.status.extracting_rom:
                 self.ui.draw_loader(
-                    self.status.extracted_percent, 
+                    self.status.extracted_percent,
                     color=get_controller_layout()[1]["color"],
                 )
                 self.ui.draw_log(
@@ -226,7 +229,7 @@ class RomM:
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
-                text_line_1="Error: Permission denied", 
+                text_line_1="Error: Permission denied",
                 text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_credentials = True
@@ -310,7 +313,7 @@ class RomM:
         elif not self.status.download_rom_ready.is_set():
             if self.status.extracting_rom:
                 self.ui.draw_loader(
-                    self.status.extracted_percent, 
+                    self.status.extracted_percent,
                     color=get_controller_layout()[1]["color"],
                 )
                 self.ui.draw_log(
@@ -333,7 +336,7 @@ class RomM:
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
-                text_line_1="Error: Permission denied", 
+                text_line_1="Error: Permission denied",
                 text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_credentials = True
@@ -458,7 +461,7 @@ class RomM:
         elif not self.status.download_rom_ready.is_set():
             if self.status.extracting_rom:
                 self.ui.draw_loader(
-                    self.status.extracted_percent, 
+                    self.status.extracted_percent,
                     color=get_controller_layout()[1]["color"],
                 )
                 self.ui.draw_log(
@@ -481,7 +484,7 @@ class RomM:
             self.status.valid_host = True
         elif not self.status.valid_credentials:
             self.ui.draw_log(
-                text_line_1="Error: Permission denied", 
+                text_line_1="Error: Permission denied",
                 text_color=get_controller_layout()[0]["color"],
             )
             self.status.valid_credentials = True
@@ -681,7 +684,7 @@ class RomM:
         next_layout = layouts[(current_idx + 1) % len(layouts)]
         self.start_menu_options[2] = (
             f"{glyphs.user} Toggle layout: {next_layout.capitalize()}",
-            self.start_menu_options[2][1]
+            self.start_menu_options[2][1],
         )
         self.ui.draw_menu_background(
             pos,

--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -1,7 +1,7 @@
 import os
 import threading
 import time
-from typing import Any, Tuple
+from typing import Any, Tuple, List, Dict
 
 import sdl2
 import sdl2.ext
@@ -17,11 +17,6 @@ from config import (
     get_controller_layout,
     set_controller_layout,
     save_controller_layout,
-    color_btn_a,
-    color_btn_b,
-    color_btn_x,
-    color_btn_y,
-    color_btn_shoulder,
 )
 from filesystem import Filesystem
 from glyps import glyphs
@@ -29,11 +24,12 @@ from input import Input
 from status import Filter, Status, View
 from ui import (
     UserInterface,
-    color_row_bg,
     color_menu_bg,
     color_text,
 )
 from update import Update
+
+ButtonConfig = Dict[str, str]
 
 
 class StartMenuOptions:
@@ -65,7 +61,7 @@ class RomM:
         self.max_n_platforms = 10
         self.max_n_collections = 10
         self.max_n_roms = 10
-        self.buttons_config = []
+        self.buttons_config: List[ButtonConfig] = []
 
         self.last_spinner_update = time.time()
         self.current_spinner_status = next(glyphs.spinner)
@@ -421,7 +417,7 @@ class RomM:
             prepend_platform_slug = True
         else:
             header_text = "ROMs"
-            header_color = color_btn_a
+            header_color = get_controller_layout()[0]["color"]
             prepend_platform_slug = False
 
         total_pages = (

--- a/RomM/ui.py
+++ b/RomM/ui.py
@@ -8,7 +8,6 @@ import sdl2
 from config import (
     color_btn_a,
     color_btn_b,
-    get_controller_layout,
 )
 from filesystem import Filesystem
 from glyps import glyphs
@@ -34,7 +33,6 @@ class UserInterface:
     screen_height = 480
     font_file = FONT_FILE
     layout_name = os.getenv("CONTROLLER_LAYOUT", "nintendo")
-    current_layout = get_controller_layout()
 
     active_image: Image.Image
     active_draw: ImageDraw.ImageDraw

--- a/RomM/ui.py
+++ b/RomM/ui.py
@@ -5,17 +5,16 @@ import time
 from typing import Optional
 
 import sdl2
+from config import (
+    color_btn_a,
+    color_btn_b,
+    get_controller_layout,
+)
 from filesystem import Filesystem
 from glyps import glyphs
 from models import Collection, Platform, Rom
 from PIL import Image, ImageDraw, ImageFont
 from status import Status
-
-from config import (
-    get_controller_layout,
-    color_btn_a,
-    color_btn_b,
-)
 
 FONT_FILE = {15: ImageFont.truetype(os.path.join(os.getcwd(), "fonts/romm.ttf"), 12)}
 
@@ -593,5 +592,7 @@ class UserInterface:
             ],
             5,
             fill=color_menu_bg,
-            outline=color_btn_a if UserInterface.layout_name == "nintendo" else color_btn_b,
+            outline=(
+                color_btn_a if UserInterface.layout_name == "nintendo" else color_btn_b
+            ),
         )

--- a/RomM/ui.py
+++ b/RomM/ui.py
@@ -13,13 +13,17 @@ from status import Status
 
 FONT_FILE = {15: ImageFont.truetype(os.path.join(os.getcwd(), "fonts/romm.ttf"), 12)}
 
-color_btn_a = "#ad3c6b"
-color_btn_b = "#bb7200"
-color_btn_x = "#3b80aa"
-color_btn_y = "#41aa3b"
-color_btn_shoulder = "#383838"
+from config import (
+    get_controller_layout,
+    color_btn_a,
+    color_btn_b,
+    color_btn_x,
+    color_btn_y,
+    color_btn_shoulder,
+)
+
+color_row_bg = "#383838"
 color_menu_bg = "#141414"
-color_sel = "#ad3c6b"
 color_progress_bar = "#3d6b39"
 color_text = "#ffffff"
 
@@ -33,6 +37,8 @@ class UserInterface:
     screen_width = 640
     screen_height = 480
     font_file = FONT_FILE
+    layout_name = os.getenv("CONTROLLER_LAYOUT", "nintendo")
+    current_layout = get_controller_layout()
 
     active_image: Image.Image
     active_draw: ImageDraw.ImageDraw
@@ -182,11 +188,13 @@ class UserInterface:
         width: int,
         height: int,
         selected: bool = False,
-        fill: str = color_sel,
+        fill: str = None,
         color: str = color_text,
         outline: str | None = None,
         append_icon_path: str | None = None,
     ):
+        if fill is None:
+            fill = color_btn_a if self.layout_name == "nintendo" else color_btn_b
         try:
             icon = Image.open(append_icon_path) if append_icon_path else None
         except (FileNotFoundError, AttributeError):
@@ -198,7 +206,7 @@ class UserInterface:
         self.draw_rectangle_r(
             [position[0], position[1], position[0] + width, position[1] + height],
             radius,
-            fill=fill if selected else color_btn_shoulder,
+            fill=fill if selected else color_row_bg,
             outline=outline,
         )
 
@@ -240,8 +248,10 @@ class UserInterface:
         position: ImageDraw.Coords,
         button: str,
         text: str,
-        color: str = color_sel,
+        color: str = None,
     ):
+        if color is None:
+            color = color_btn_a if self.layout_name == "nintendo" else color_btn_b
         radius = 10
         btn_text_offset = 1
         label_margin_l = 20
@@ -384,8 +394,11 @@ class UserInterface:
         platforms_selected_position: int,
         max_n_platforms: int,
         platforms: list[Platform],
-        fill: str = color_sel,
+        fill: str = None,
     ):
+        if fill is None:
+            fill = color_btn_a if self.layout_name == "nintendo" else color_btn_b
+
         self.draw_rectangle_r(
             [10, 50, self.screen_width - 10, 100], 5, outline=color_menu_bg
         )
@@ -426,8 +439,11 @@ class UserInterface:
         collections_selected_position: int,
         max_n_collections: int,
         collections: list[Collection],
-        fill: str = color_sel,
+        fill: str = None,
     ):
+        if fill is None:
+            fill = color_btn_b if self.layout_name == "nintendo" else color_btn_a
+
         self.draw_rectangle_r(
             [10, 50, self.screen_width - 10, 100], 5, outline=color_menu_bg
         )
@@ -580,5 +596,5 @@ class UserInterface:
             ],
             5,
             fill=color_menu_bg,
-            outline=color_sel,
+            outline=color_btn_a if UserInterface.layout_name == "nintendo" else color_btn_b,
         )

--- a/RomM/ui.py
+++ b/RomM/ui.py
@@ -11,16 +11,13 @@ from models import Collection, Platform, Rom
 from PIL import Image, ImageDraw, ImageFont
 from status import Status
 
-FONT_FILE = {15: ImageFont.truetype(os.path.join(os.getcwd(), "fonts/romm.ttf"), 12)}
-
 from config import (
     get_controller_layout,
     color_btn_a,
     color_btn_b,
-    color_btn_x,
-    color_btn_y,
-    color_btn_shoulder,
 )
+
+FONT_FILE = {15: ImageFont.truetype(os.path.join(os.getcwd(), "fonts/romm.ttf"), 12)}
 
 color_row_bg = "#383838"
 color_menu_bg = "#141414"
@@ -188,7 +185,7 @@ class UserInterface:
         width: int,
         height: int,
         selected: bool = False,
-        fill: str = None,
+        fill: Optional[str] = None,
         color: str = color_text,
         outline: str | None = None,
         append_icon_path: str | None = None,
@@ -248,7 +245,7 @@ class UserInterface:
         position: ImageDraw.Coords,
         button: str,
         text: str,
-        color: str = None,
+        color: Optional[str] = None,
     ):
         if color is None:
             color = color_btn_a if self.layout_name == "nintendo" else color_btn_b
@@ -394,7 +391,7 @@ class UserInterface:
         platforms_selected_position: int,
         max_n_platforms: int,
         platforms: list[Platform],
-        fill: str = None,
+        fill: Optional[str] = None,
     ):
         if fill is None:
             fill = color_btn_a if self.layout_name == "nintendo" else color_btn_b
@@ -439,7 +436,7 @@ class UserInterface:
         collections_selected_position: int,
         max_n_collections: int,
         collections: list[Collection],
-        fill: str = None,
+        fill: Optional[str] = None,
     ):
         if fill is None:
             fill = color_btn_b if self.layout_name == "nintendo" else color_btn_a


### PR DESCRIPTION
- Nintendo / Xbox button layouts now in new file `config.py`
- New menu option allows user to toggle between the two layouts
- Layout saved to `.env` on toggle
- Layouts swap colors for A-B and X-Y as well as Platforms/Collections views
- Letters on buttons remain the same, only sdl positions swap

![image](https://github.com/user-attachments/assets/403f0868-7128-4eb8-9718-a5036277c915)
