### PR TITLE
Resolve UI error

### DIFF
--- a/RomM/romm.py
+++ b/RomM/romm.py
@@ -49,7 +49,7 @@ class RomM:
         self.input = Input()
         self.status = Status()
         self.ui = UserInterface()
-        self.updater = Update()
+        self.updater = Update(self.ui)
 
         self.contextual_menu_options: list[Tuple[str, int, Any]] = []
         self.start_menu_selected_position = 0

--- a/RomM/ui.py
+++ b/RomM/ui.py
@@ -25,6 +25,7 @@ color_text = "#ffffff"
 
 class UserInterface:
     _instance: Optional["UserInterface"] = None
+    _initialized: bool = False
 
     fs = Filesystem()
     status = Status()
@@ -38,10 +39,13 @@ class UserInterface:
     active_draw: ImageDraw.ImageDraw
 
     def __init__(self):
+        if self._initialized:
+            return
         self.window = self._create_window()
         self.renderer = self._create_renderer()
         self.draw_start()
         self.opt_stretch = True
+        self._initialized = True
 
     def __new__(cls):
         if not cls._instance:

--- a/RomM/update.py
+++ b/RomM/update.py
@@ -8,14 +8,13 @@ from filesystem import Filesystem
 from glyps import glyphs
 from semver import Version
 from status import Status
-from ui import UserInterface
 
 
 class Update:
     github_repo = "rommapp/muos-app"
 
-    def __init__(self):
-        self.ui = UserInterface()
+    def __init__(self, ui):
+        self.ui = ui
         self.status = Status()
         self.filesystem = Filesystem()
         self.current_version = self.get_current_version()


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD033) -->
<!-- trunk-ignore-all(markdownlint/MD041) -->

**Description**
UserInterface had two instances created which conflicted, in romm.py and update.py. Resolve to maintain a single instance.

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [x] I've assigned reviewers for this PR

#### Screenshots
