### PR TITLE
enable custom mapping in the .env

### DIFF
--- a/RomM/api.py
+++ b/RomM/api.py
@@ -257,7 +257,7 @@ class API:
                     and platform_slug in platform_maps._env_platforms
                     and platform_slug not in self._exclude_platforms
                 ):
-                  # A custom map from the .env was found, no need to check defaults
+                    # A custom map from the .env was found, no need to check defaults
                     pass
                 elif self.file_system.is_muos:
                     if (
@@ -459,7 +459,10 @@ class API:
         _roms = []
         for rom in roms:
             platform_slug = rom["platform_slug"].lower()
-            if platform_maps._env_maps and platform_slug in platform_maps._env_platforms:
+            if (
+                platform_maps._env_maps
+                and platform_slug in platform_maps._env_platforms
+            ):
                 pass
             elif self.file_system.is_muos:
                 if platform_slug not in platform_maps.MUOS_SUPPORTED_PLATFORMS:

--- a/RomM/api.py
+++ b/RomM/api.py
@@ -252,7 +252,14 @@ class API:
         for platform in platforms:
             if platform["rom_count"] > 0:
                 platform_slug = platform["slug"].lower()
-                if self.file_system.is_muos:
+                if (
+                    platform_maps._env_maps
+                    and platform_slug in platform_maps._env_platforms
+                    and platform_slug not in self._exclude_platforms
+                ):
+                  # A custom map from the .env was found, no need to check defaults
+                    pass
+                elif self.file_system.is_muos:
                     if (
                         platform_slug not in platform_maps.MUOS_SUPPORTED_PLATFORMS
                         or platform_slug in self._exclude_platforms
@@ -452,7 +459,9 @@ class API:
         _roms = []
         for rom in roms:
             platform_slug = rom["platform_slug"].lower()
-            if self.file_system.is_muos:
+            if platform_maps._env_maps and platform_slug in platform_maps._env_platforms:
+                pass
+            elif self.file_system.is_muos:
                 if platform_slug not in platform_maps.MUOS_SUPPORTED_PLATFORMS:
                     continue
             elif self.file_system.is_spruceos:

--- a/RomM/env.template
+++ b/RomM/env.template
@@ -15,3 +15,8 @@ COLLECTION_TYPE=collection
 
 # Do not display collections with these names (comma separated)
 # EXCLUDE_COLLECTIONS=""
+
+# Map RomM slugs to filesystem directories
+# For example, if your PlayStation directory is called "psx":
+# CUSTOM_MAPS='{"ps": "psx"}'
+# CUSTOM_MAPS=''

--- a/RomM/filesystem.py
+++ b/RomM/filesystem.py
@@ -97,9 +97,7 @@ class Filesystem:
             )
 
         if platform_maps._env_maps and platform in platform_maps._env_platforms:
-            platform_dir = platform_maps._env_maps.get(
-                platform, platform_dir
-            )
+            platform_dir = platform_maps._env_maps.get(platform, platform_dir)
 
         return platform_dir
 

--- a/RomM/filesystem.py
+++ b/RomM/filesystem.py
@@ -96,6 +96,11 @@ class Filesystem:
                 platform, platform_dir
             )
 
+        if platform_maps._env_maps and platform in platform_maps._env_platforms:
+            platform_dir = platform_maps._env_maps.get(
+                platform, platform_dir
+            )
+
         return platform_dir
 
     def _get_sd1_platforms_storage_path(self, platform: str) -> str:

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import zipfile
+
 import platform_maps
 
 # Add dependencies to path
@@ -51,6 +52,7 @@ if not apply_pending_update():
 
     # Read any custom maps
     platform_maps.init_env_maps()
+
 
 def cleanup(romm: RomM, exit_code: int):
     romm.ui.cleanup()

--- a/RomM/main.py
+++ b/RomM/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import zipfile
+import platform_maps
 
 # Add dependencies to path
 base_path = os.path.dirname(os.path.abspath(__file__))
@@ -48,6 +49,8 @@ if not apply_pending_update():
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     sys.stdout = open(log_file, "w", buffering=1)
 
+    # Read any custom maps
+    platform_maps.init_env_maps()
 
 def cleanup(romm: RomM, exit_code: int):
     romm.ui.cleanup()

--- a/RomM/platform_maps.py
+++ b/RomM/platform_maps.py
@@ -1,3 +1,6 @@
+import os
+import json
+
 # Manual mapping of RomM slugs to device folder names and platform icons for es systems
 # This is sometimes needed to match custom system folders with defaults, for example ES-DE uses roms/gc and some Batocera forks use roms/gamecube
 # https://gitlab.com/es-de/emulationstation-de/-/blob/master/resources/systems/unix/es_systems.xml
@@ -192,3 +195,28 @@ SPRUCEOS_SUPPORTED_PLATFORMS = frozenset(SPRUCEOS_SUPPORTED_PLATFORMS_FS_MAP.key
 SPRUCEOS_SUPPORTED_PLATFORMS_FS = frozenset(
     SPRUCEOS_SUPPORTED_PLATFORMS_FS_MAP.values()
 )
+
+_env_maps = None
+_env_platforms = None
+
+def _load_env_maps() -> dict[str, str]:
+    raw = os.getenv("CUSTOM_MAPS")
+    if not raw:
+        return {}
+    try:
+        loaded = json.loads(raw)
+        return loaded
+    except json.JSONDecodeError as e:
+        print(f"Error: CUSTOM_MAPS is an invalid JSON format: {e}")
+        return {}
+    except Exception as e:
+        print(f"Error: Unexpected error: {e}")
+        return {}
+
+def init_env_maps():
+    global _env_maps
+    global _env_platforms
+    if _env_maps is None:
+        _env_maps = _load_env_maps()
+    if _env_platforms is None:
+        _env_platforms = frozenset(_env_maps.keys())

--- a/RomM/platform_maps.py
+++ b/RomM/platform_maps.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 # Manual mapping of RomM slugs to device folder names and platform icons for es systems
 # This is sometimes needed to match custom system folders with defaults, for example ES-DE uses roms/gc and some Batocera forks use roms/gamecube
@@ -199,6 +199,7 @@ SPRUCEOS_SUPPORTED_PLATFORMS_FS = frozenset(
 _env_maps = None
 _env_platforms = None
 
+
 def _load_env_maps() -> dict[str, str]:
     raw = os.getenv("CUSTOM_MAPS")
     if not raw:
@@ -212,6 +213,7 @@ def _load_env_maps() -> dict[str, str]:
     except Exception as e:
         print(f"Error: Unexpected error: {e}")
         return {}
+
 
 def init_env_maps():
     global _env_maps


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD033) -->
<!-- trunk-ignore-all(markdownlint/MD041) -->

**Description**
This commit enables custom mapping from the system names used in RomM to the directory name used on the device.

**Checklist**
<sup>Please check all that apply.</sup>
- [X] I've tested the changes locally
- [X] I've updated relevant comments
- [ ] I've assigned reviewers for this PR

