### PR TITLE
Handles relative image URLs and ensures dir exists

### DIFF
--- a/RomM/api.py
+++ b/RomM/api.py
@@ -652,6 +652,7 @@ class API:
             )
             if not catalogue_path:
                 continue
+            os.makedirs(catalogue_path, exist_ok=True)
 
             filename = self._sanitize_filename(rom.fs_name_no_ext)
             if rom.summary:

--- a/RomM/imageutils.py
+++ b/RomM/imageutils.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from typing import Optional
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from urllib.parse import urljoin
 
 from PIL import Image, ImageDraw
 
@@ -54,9 +55,9 @@ class ImageUtils:
 
     def load_image_from_url(self, url: str, headers: dict) -> Image.Image | None:
         try:
-            # If URL is relative (doesn't start with http:// or https://), prepend host
-            if url and not url.startswith(("http://", "https://")):
-                url = f"{self.host}{url}"
+            # Use urljoin to properly resolve relative URLs against the host
+            if url:
+                url = urljoin(f'{self.host}/', url)
             
             req = Request(url.split("?")[0], headers=headers)
             with urlopen(req, timeout=60) as response:  # trunk-ignore(bandit/B310)

--- a/RomM/imageutils.py
+++ b/RomM/imageutils.py
@@ -54,6 +54,10 @@ class ImageUtils:
 
     def load_image_from_url(self, url: str, headers: dict) -> Image.Image | None:
         try:
+            # If URL is relative (doesn't start with http:// or https://), prepend host
+            if url and not url.startswith(("http://", "https://")):
+                url = f"{self.host}{url}"
+            
             req = Request(url.split("?")[0], headers=headers)
             with urlopen(req, timeout=60) as response:  # trunk-ignore(bandit/B310)
                 data = response.read()

--- a/RomM/imageutils.py
+++ b/RomM/imageutils.py
@@ -2,8 +2,8 @@ import os
 from io import BytesIO
 from typing import Optional
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 from urllib.parse import urljoin
+from urllib.request import Request, urlopen
 
 from PIL import Image, ImageDraw
 
@@ -57,8 +57,8 @@ class ImageUtils:
         try:
             # Use urljoin to properly resolve relative URLs against the host
             if url:
-                url = urljoin(f'{self.host}/', url)
-            
+                url = urljoin(f"{self.host}/", url)
+
             req = Request(url.split("?")[0], headers=headers)
             with urlopen(req, timeout=60) as response:  # trunk-ignore(bandit/B310)
                 data = response.read()


### PR DESCRIPTION
<!-- trunk-ignore-all(markdownlint/MD033) -->
<!-- trunk-ignore-all(markdownlint/MD041) -->

**Description**
<sup>Explain the changes or enhancements you are proposing with this pull request.</sup>

This PR addresses two issues that could cause failures when downloading and processing ROM assets:

1. **Relative URL handling**: The `load_image_from_url` method in `ImageUtils` now automatically prepends the host URL (from the `HOST` environment variable) to relative image URLs. Previously, relative URLs like `/api/images/cover.png` would fail to load because they lacked a full domain. Now, if a URL doesn't start with `http://` or `https://`, the host is automatically prepended, ensuring images load correctly regardless of whether the API returns absolute or relative URLs.

2. **Directory creation**: Added `os.makedirs(catalogue_path, exist_ok=True)` in the `download_rom` method to ensure the catalogue directory exists before attempting to write ROM metadata and assets. This prevents `FileNotFoundError` exceptions when the catalogue directory structure hasn't been initialized yet.

**Changes Made**
- Modified `RomM/imageutils.py`: Added logic to detect and prepend host URL to relative image URLs in `load_image_from_url` method
- Modified `RomM/api.py`: Added directory creation for catalogue path before writing ROM metadata and assets

**Testing**
- Tested with both relative and absolute image URLs
- Verified that catalogue directories are created automatically when needed
- Confirmed that existing absolute URLs continue to work without modification

**Checklist**
<sup>Please check all that apply.</sup>

- [x] I've tested the changes locally
- [x] I've updated relevant comments
- [ ] I've assigned reviewers for this PR

#### Screenshots